### PR TITLE
Fix contact section syntax error

### DIFF
--- a/src/config/portfolioConfig.ts
+++ b/src/config/portfolioConfig.ts
@@ -224,7 +224,8 @@ export const portfolioConfig = {
       {
         type: "github",
         label: "GitHub",
-        url: "https://github.com/Nikolaj-Storm
+        url: "https://github.com/Nikolaj-Storm"
+      }
     ]
   },
 


### PR DESCRIPTION
## Summary
- fix missing closing quote and brace in `portfolioConfig.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68601f2b632c832e87b31e086e639292